### PR TITLE
ID006: String can not contain hash as a valid character

### DIFF
--- a/parser/src/velocity.jison
+++ b/parser/src/velocity.jison
@@ -12,6 +12,7 @@ LETTER              [a-zA-Z\_\-]
 SLETTER             [a-zA-Z]
 NEWLINE             \n
 SPACE               \s
+STRING_PUNCT	    [!%$#&+,-/:;<=>?@[\]^_`|()~.]
 PUNCT		    [!%$&+,-/:;<=>?@[\]^_`|()~.]
 SPECIAL_CHAR	    [%*&+,-/:;<=>?@[\]^_`|()~.]
 
@@ -165,7 +166,7 @@ SPECIAL_CHAR	    [%*&+,-/:;<=>?@[\]^_`|()~.]
 					this.popState(); 
 					return 'SINGLEQUOTE'
 				}
-<INSTRING>(({SLETTER}|{DIGIT}|{PUNCT}|{SPACE})*) 
+<INSTRING>(({SLETTER}|{DIGIT}|{STRING_PUNCT}|{SPACE})*) 
 			        return 'STRING'
 <VELOCITY>"in"                  return 'IN'
 <VELOCITY>"and"                 return 'AND'


### PR DESCRIPTION
Parsed the following file

#set( $greatlakes = ["Superior","Michigan","Huron","Erie","Ontario"] )
#set( $color = "blue" )
<table>
  #tablerows( $color $greatlakes )
</table>
#set( $parts = ["volva","stipe","annulus","gills","pileus"] )
#set( $cellbgcol = "#CC00FF" )
<table>
  #tablerows( $cellbgcol $parts )
</table>

Parser generated following result

ASSIGNED  		$greatlakes
STRING    		Superior
STRING    		Michigan
STRING    		Huron
STRING    		Erie
STRING    		Ontario
ASSIGNED  		$color
STRING    		blue
ASSIGNED  		$parts
STRING    		volva
STRING    		stipe
STRING    		annulus
STRING    		gills
STRING    		pileus
ASSIGNED  		$cellbgcol
STRING    		#CC00FF
